### PR TITLE
Adding Makefile for building ocitools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+BUILDTAGS=
+export GOPATH:=$(CURDIR)/Godeps/_workspace:$(GOPATH)
+
+all:
+	go build -tags "$(BUILDTAGS)" -o ocitools .
+	go build -tags "$(BUILDTAGS)" -o runtimetest ./cmd/runtimetest
+
+install:
+	cp ocitools /usr/local/bin/ocitools
+
+clean:
+	rm ocitools runtimetest


### PR DESCRIPTION
@mrunalp 
Got the following error with the latest specs ( Swapiness is -1 in generate.go, but the latest specs had uint64)
github.com/mrunalp/ocitools
./generate.go:538: constant -1 overflows uint64

Added Makefile to build the ocitools.

Signed-off-by: rajasec rajasec79@gmail.com
